### PR TITLE
Skip metric if name is empty.

### DIFF
--- a/lib/metriks/librato_metrics_reporter.rb
+++ b/lib/metriks/librato_metrics_reporter.rb
@@ -84,6 +84,7 @@ module Metriks
       time = @time_tracker.now_floored
 
       @registry.each do |name, metric|
+        next if name.nil? || name.blank?
         name = name.to_s.gsub(/ +/, '_')
 
         if prefix


### PR DESCRIPTION
Don't ask me why or where, we have a metric with an empty name. But probably makes sense to catch this regardless? Librato doesn't like empty metrics names.
