### PR TITLE
We need to ensure to clean the data

### DIFF
--- a/lib/metriks/librato_metrics_reporter.rb
+++ b/lib/metriks/librato_metrics_reporter.rb
@@ -94,7 +94,7 @@ module Metriks
       else
         res.error!
       end
-
+    ensure
       @data.clear
     end
 


### PR DESCRIPTION
If there is any error on Librato API, or any error in general on the
HTTP connection, we still need to clear the data otherwise memory would
leak.

see https://www.dropbox.com/s/zpo7obfcn27ek3o/Screenshot%202015-02-28%2019.32.04.png?dl=0

You can see that memory grows right after we stop getting data from `app`, `ruby.variance`. Also we can see in our logs lots of occurrences like: `LibratoMetrics: Broken pipe`.
My guess is that, at somepoint the data we are sending to Librato gets too big, and Librato closes the connection while we are sending. Regardless, we cannot leaky memory! 
This is making us, on bundler-api, have to restart our servers as memory is leaking.

cc @indirect @andremedeiros