### PR TITLE
Do not send empty source to API

### DIFF
--- a/lib/metriks/librato_metrics_reporter.rb
+++ b/lib/metriks/librato_metrics_reporter.rb
@@ -161,9 +161,12 @@ module Metriks
       end
 
       @data["gauges[#{idx}][name]"]         = name
-      @data["gauges[#{idx}][source]"]       = @source
       @data["gauges[#{idx}][measure_time]"] = time.to_i
       @data["gauges[#{idx}][value]"]        = value
+
+      unless @source.to_s.empty?
+        @data["gauges[#{idx}][source]"] = @source
+      end
 
       unless @sent[name]
         @sent[name] = true

--- a/test/librato_metrics_reporter_test.rb
+++ b/test/librato_metrics_reporter_test.rb
@@ -72,4 +72,22 @@ class LibratoMetricsReporterTest < Test::Unit::TestCase
     end
   end
 
+  def test_write_with_source_unset
+    @registry.meter('meter.testing').mark
+
+    @reporter.expects(:submit)
+    @reporter.write
+
+    assert @reporter.data.none? { |(k,v)| k =~ /gauges\[\d+\]\[source\]/ }
+  end
+
+  def test_write_with_source_set
+    @reporter = build_reporter(:source => "localhost")
+    @registry.meter('meter.testing').mark
+
+    @reporter.expects(:submit)
+    @reporter.write
+
+    assert @reporter.data.detect { |(k,v)| k =~ /gauges\[\d+\]\[source\]/ && v = "localhost " }
+  end
 end


### PR DESCRIPTION
The source parameter is optional, but a recent change in the Librato API invalidates empty parameters as well. If an empty source is sent, the API will respond with "400 Bad request".